### PR TITLE
Added intercepting function for calls to sys.setrecursionlimit()

### DIFF
--- a/filetypes/pythonfile.py
+++ b/filetypes/pythonfile.py
@@ -427,6 +427,20 @@ class PythonFile(PlainFile):
         results = dict()
         results[self] = []
 
+        actual_setrecursionlimit = sys.setrecursionlimit
+
+        def intercept_stacksize_change(new_val):
+            sprint("intercepting call to sys.setrecursionlimit()")
+            old_val = sys.getrecursionlimit()
+            if new_val < old_val:
+                sprint("keeping stack size at " + str(old_val))
+                return
+            else:
+                sprint("growing stack size to " + str(new_val))
+                actual_setrecursionlimit(new_val)
+
+        sys.setrecursionlimit = intercept_stacksize_change
+
         try:
             directory, name = os.path.split(self.path)
             mod_name = name[:name.index('.py')] if '.py' in name else name


### PR DESCRIPTION
It was possible for students to set the stack size to something very
small (so small that other Python modules would cause a stack overflow
during normal operation). socrates now protects the stack size from
getting any smaller than it is by default.
